### PR TITLE
initializes database with default users [NodeJS]

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,8 +1,3 @@
-
-
-// imports dependencies:
-
-
 const dotenv = require("dotenv");	// for importing environment variables
 dotenv.config();			// imports environment variables from .env file
 

--- a/config/index.js
+++ b/config/index.js
@@ -16,6 +16,11 @@ const config = {
       secretKey: process.env.JWT_SECRET_KEY,
       headerKey: process.env.JWT_HEADER_KEY
     }
+  },
+
+  // sets the database connection string
+  db: {
+    connectionString: process.env.DB_CONNECTION_STRING
   }
 
 };
@@ -31,7 +36,7 @@ source: index.js
 author: @misael-diaz
 
 Synopsis:
-Configures the HTTP Host and Port of the App.
+Configures the HTTP Host and Port of the App and the Database Connection String.
 
 
 Copyright (c) 2023 Misael Diaz-Maldonado

--- a/config/index.js
+++ b/config/index.js
@@ -4,19 +4,19 @@ dotenv.config();			// imports environment variables from .env file
 
 const config = {
 
-	// sets the Host and Port from Environment variables or from defaults if undefined
-	http: {
-		host: process.env.HTTP_HOST || "0.0.0.0",
-		port: process.env.HTTP_PORT || 8080
-	},
+  // sets the Host and Port from Environment variables or from defaults if undefined
+  http: {
+    host: process.env.HTTP_HOST || "0.0.0.0",
+    port: process.env.HTTP_PORT || 8080
+  },
 
-	// sets the jsonwebtoken `jwt' header and secret keys
-	jwt: {
-		token: {
-			secretKey: process.env.JWT_SECRET_KEY,
-			headerKey: process.env.JWT_HEADER_KEY
-		}
-	}
+  // sets the jsonwebtoken `jwt' header and secret keys
+  jwt: {
+    token: {
+      secretKey: process.env.JWT_SECRET_KEY,
+      headerKey: process.env.JWT_HEADER_KEY
+    }
+  }
 
 };
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,24 +1,3 @@
-/*
-
-Twitter API							February 17, 2023
-
-source: index.js
-author: @misael-diaz
-
-Synopsis:
-Configures the HTTP Host and Port of the App.
-
-
-Copyright (c) 2023 Misael Diaz-Maldonado
-This file is released under the GNU General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-
-References:
-[0] main: https://github.com/jestrade/api-twitter
-
-*/
 
 
 // imports dependencies:
@@ -48,3 +27,25 @@ const config = {
 
 
 module.exports = config;		// exports the configuration object `config'
+
+/*
+
+Twitter API							February 17, 2023
+
+source: index.js
+author: @misael-diaz
+
+Synopsis:
+Configures the HTTP Host and Port of the App.
+
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+
+References:
+[0] main: https://github.com/jestrade/api-twitter
+
+*/

--- a/http/index.js
+++ b/http/index.js
@@ -27,21 +27,21 @@ app.use("/api", api);			// mounts API at /api
 
 // configures the app to answer HTTP GET request to the root route `/':
 app.get("/", (req, res) => {
-	res.send("App works!");
+  res.send("App works!");
 });
 
 
 // configures the app to handle undefined HTTP GET routes:
 app.get("*", (req, res) => {
-	res.send("undefined route");
+  res.send("undefined route");
 });
 
 
 // defines the start() method for starting the HTTP App:
 const start = () => {
-	app.listen(port, host, () => {
-		console.log(`server running at http://${host}:${port}`);
-	});
+  app.listen(port, host, () => {
+    console.log(`server running at http://${host}:${port}`);
+  });
 };
 
 

--- a/http/index.js
+++ b/http/index.js
@@ -1,29 +1,3 @@
-/*
-
-Twitter API							February 17, 2023
-
-source: index.js
-author: @misael-diaz
-
-Synopsis:
-Exports HTTP App start() method.
-
-
-Copyright (c) 2023 Misael Diaz-Maldonado
-This file is released under the GNU General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-
-References:
-[0] main resource: https://github.com/jestrade/api-twitter
-[1] API: https://www.ibm.com/topics/api
-[2] NODEJS REST API: https://medium.com/bb-tutorials-and-thoughts/how-to-write-production-ready-node-js-rest-api-javascript-version-db64d3941106
-[3] app.use(): https://www.geeksforgeeks.org/express-js-app-use-function/
-[4] express.json(): https://www.geeksforgeeks.org/express-js-express-json-function/
-[5] app.get(): https://www.geeksforgeeks.org/express-js-app-get-request-function/
-
-*/
 
 
 // imports dependencies:
@@ -72,3 +46,30 @@ const start = () => {
 
 
 module.exports = { start };		// exports object storing the start() method
+
+/*
+
+Twitter API							February 17, 2023
+
+source: index.js
+author: @misael-diaz
+
+Synopsis:
+Exports HTTP App start() method.
+
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+
+References:
+[0] main resource: https://github.com/jestrade/api-twitter
+[1] API: https://www.ibm.com/topics/api
+[2] NODEJS REST API: https://medium.com/bb-tutorials-and-thoughts/how-to-write-production-ready-node-js-rest-api-javascript-version-db64d3941106
+[3] app.use(): https://www.geeksforgeeks.org/express-js-app-use-function/
+[4] express.json(): https://www.geeksforgeeks.org/express-js-express-json-function/
+[5] app.get(): https://www.geeksforgeeks.org/express-js-app-get-request-function/
+
+*/

--- a/http/index.js
+++ b/http/index.js
@@ -1,8 +1,3 @@
-
-
-// imports dependencies:
-
-
 const express = require("express");	// imports express
 const api = require("../api");		// imports API router
 const { http } = require("../config");	// gets http object from config by deconstruction

--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
+const { start } = require("./http");		// imports the http start() method
+const seeds = require("./seeds");		// starts and seeds the database
+
+start();					// starts the http app
+
 /*
 
 Twitter API							February 17, 2023
@@ -19,6 +24,3 @@ References:
 [0] https://github.com/jestrade/api-twitter
 
 */
-
-const { start } = require("./http");		// imports the http start() method
-start();					// starts the http app

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.0.3",
     "n": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-	  "start": "node index.js"
+    "start": "node index.js"
   },
   "repository": "git@github.com:misael-diaz/twitter-api.git",
   "author": "misael-diaz <20134959+misael-diaz@users.noreply.github.com>",
   "license": "GPL-3.0-or-later",
-  "private": false
+  "private": false,
+  "dependencies": {
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "n": "^9.0.1"
+  }
 }

--- a/seeds/data.js
+++ b/seeds/data.js
@@ -1,0 +1,40 @@
+const data = [
+  {
+    firstName: "Administrator",
+    lastName: "User",
+    email: "admin.user@twitter.api.com",
+    username: "admin",
+    password: "4dm1n.Password"
+  },
+  {
+    firstName: "Normal",
+    lastName: "User",
+    email: "normal.user@twitter.api.com",
+    username: "user",
+    password: "us3r.Password"
+  }
+];
+
+module.exports = { data };
+
+/*
+
+Twitter API							March 27, 2023
+
+source: data.js
+author: @misael-diaz
+
+Synopsis:
+Defines default user accounts.
+
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+
+References:
+[0] https://github.com/jestrade/api-twitter
+
+*/

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -1,0 +1,40 @@
+const { connect } = require("../db");
+const { data } = require("./data");
+const users = require("../api/users/users");
+
+(async () => {
+
+  await connect();
+
+  data.forEach( async (elem) => {
+
+    const user = new users(elem);
+    await user.save();
+
+  });
+
+  console.log(`database has been seeded!`);
+
+})();
+
+/*
+
+Twitter API							March 27, 2023
+
+source: index.js
+author: @misael-diaz
+
+Synopsis:
+Seeds default user accounts to the database.
+
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+
+References:
+[0] https://github.com/jestrade/api-twitter
+
+*/


### PR DESCRIPTION
Adds code to connect and seed (or initialize) the database with default users (an administrator and normal user accounts).

Performs style changes, mostly indentation, as indicated in the commit messages.

Notes:
As a consequence of upgrading to the latest version of NPM, package.json and package-lock.json were updated.